### PR TITLE
feat: swatches can manage image urls and base64 encoded images

### DIFF
--- a/packages/website/src/components/FacetsAppearance/FacetColorSwatch.tsx
+++ b/packages/website/src/components/FacetsAppearance/FacetColorSwatch.tsx
@@ -1,5 +1,6 @@
 import { Swatch } from '#components/Swatch'
 import { useCatalogContext } from '#contexts/CatalogContext'
+import { stringToBackground } from '#utils/css'
 import type { Primitives } from '#utils/facets'
 import { useI18n } from 'next-localization'
 
@@ -14,7 +15,7 @@ export const FacetColorSwatch = ({ facetName, facetValues }: { facetName: string
           <Swatch
             key={currentValue.toString()}
             swatchLabel={i18n.t(`search.values.${currentValue.toString()}`) || currentValue.toString() }
-            swatchStyle={{ [currentValue.toString().toLowerCase().includes('gradient') ? 'backgroundImage' : 'backgroundColor']: currentValue.toString() }}
+            swatchStyle={stringToBackground(currentValue.toString())}
             onClick={() => selectFacet(facetName, currentValue)}
             selected={selectedFacets[facetName]?.includes(currentValue) }
           />

--- a/packages/website/src/components/Page.tsx
+++ b/packages/website/src/components/Page.tsx
@@ -1,6 +1,6 @@
 import { NEXT_PUBLIC_BASE_PATH } from '#utils/envs'
 import { useSettingsContext } from '#contexts/SettingsContext'
-import { getRGBColor } from '#utils/color'
+import { getRGBColor } from '#utils/css'
 import { useI18n } from 'next-localization'
 import Head from 'next/head'
 import { useRouter } from 'next/router'

--- a/packages/website/src/components/Swatch.tsx
+++ b/packages/website/src/components/Swatch.tsx
@@ -13,7 +13,7 @@ export const Swatch: React.FC<Props> = ({ selected = false, swatchStyle, swatchL
       { ...props }
       className={`w-12 h-12 rounded-full inline-flex items-center justify-center my-1 mr-2 ${isSelectedClass}`}
     >
-      <div className='w-8 h-8 border border-gray-600 rounded-full' style={swatchStyle}>
+      <div className='w-8 h-8 border border-gray-600 rounded-full bg-contain' style={swatchStyle}>
         <span className='sr-only'>{swatchLabel}</span>
       </div>
     </button>

--- a/packages/website/src/components/VariantSelector.tsx
+++ b/packages/website/src/components/VariantSelector.tsx
@@ -7,6 +7,7 @@ import { useImmer } from 'use-immer'
 import { Swatch } from './Swatch'
 import { Tag } from './Tag'
 import { compareVariants, getOptions } from './VariantSelector.utils'
+import { stringToBackground } from '#utils/css'
 
 type Props = {
   product: LocalizedProductWithVariant
@@ -81,7 +82,7 @@ export const VariantSelector: React.FC<Props> = ({ product, onChange = () => {} 
                         <Swatch
                           key={`${variantName}-${variant.value}`}
                           swatchLabel={i18n.t(`search.values.${variant.value}`) || variant.value}
-                          swatchStyle={{ [variant.value.toString().toLowerCase().includes('gradient') ? 'backgroundImage' : 'backgroundColor']: variant.value.toString() }}
+                          swatchStyle={stringToBackground(variant.value)}
                           selected={selected}
                           onClick={() => {
                             setCurrentVariant((draft) => {
@@ -93,7 +94,7 @@ export const VariantSelector: React.FC<Props> = ({ product, onChange = () => {} 
                     case 'tag':
                       return (
                         <Tag
-                          key={`${variantName}-${variant.value}`}
+                          key={`${variantName}-${variant.value.toString()}`}
                           selected={selected}
                           onClick={() => {
                             setCurrentVariant((draft) => {
@@ -101,7 +102,7 @@ export const VariantSelector: React.FC<Props> = ({ product, onChange = () => {} 
                             })
                           }}
                         >
-                          {i18n.t(`search.values.${variant.value}`) || variant.value}
+                          {i18n.t(`search.values.${variant.value.toString()}`) || variant.value.toString()}
                         </Tag>
                       )
                   }

--- a/packages/website/src/pages/[locale]/product/__snapshots__/ProductPageComponent.test.tsx.snap
+++ b/packages/website/src/pages/[locale]/product/__snapshots__/ProductPageComponent.test.tsx.snap
@@ -157,7 +157,7 @@ exports[`product detail page 1`] = `
                 class="w-12 h-12 rounded-full inline-flex items-center justify-center my-1 mr-2 border border-gray-300 bg-gray-100"
               >
                 <div
-                  class="w-8 h-8 border border-gray-600 rounded-full"
+                  class="w-8 h-8 border border-gray-600 rounded-full bg-contain"
                 >
                   <span
                     class="sr-only"
@@ -170,7 +170,7 @@ exports[`product detail page 1`] = `
                 class="w-12 h-12 rounded-full inline-flex items-center justify-center my-1 mr-2 "
               >
                 <div
-                  class="w-8 h-8 border border-gray-600 rounded-full"
+                  class="w-8 h-8 border border-gray-600 rounded-full bg-contain"
                 >
                   <span
                     class="sr-only"

--- a/packages/website/src/utils/color.test.ts
+++ b/packages/website/src/utils/color.test.ts
@@ -1,9 +1,0 @@
-import { getRGBColor } from './color'
-
-describe('getRGBColor', () => {
-  it('should convert hex to rgb', () => {
-    expect(getRGBColor('#FFFFFF')).toEqual('255, 255, 255')
-    expect(getRGBColor('#000000')).toEqual('0, 0, 0')
-    expect(getRGBColor('#666EFF')).toEqual('102, 110, 255')
-  })
-})

--- a/packages/website/src/utils/color.ts
+++ b/packages/website/src/utils/color.ts
@@ -1,9 +1,0 @@
-export const getRGBColor = (hex: string) => {
-  let color = hex.replace(/#/g, '')
-
-  var r = parseInt(color.substring(0, 2), 16)
-  var g = parseInt(color.substring(2, 4), 16)
-  var b = parseInt(color.substring(4, 6), 16)
-
-  return `${r}, ${g}, ${b}`
-}

--- a/packages/website/src/utils/css.test.ts
+++ b/packages/website/src/utils/css.test.ts
@@ -1,0 +1,18 @@
+import { getRGBColor, stringToBackground } from './css'
+
+describe('getRGBColor', () => {
+  it('should convert hex to rgb', () => {
+    expect(getRGBColor('#FFFFFF')).toEqual('255, 255, 255')
+    expect(getRGBColor('#000000')).toEqual('0, 0, 0')
+    expect(getRGBColor('#666EFF')).toEqual('102, 110, 255')
+  })
+})
+
+describe('stringToBackground', () => {
+  it('should convert a given string to a valid CSS property by checking the content of the given string', () => {
+    expect(stringToBackground('#000000')).toEqual({ backgroundColor: '#000000' })
+    expect(stringToBackground('linear-gradient(0.25turn, #3f87a6, #ebf8e1, #f69d3c)')).toEqual({ backgroundImage: 'linear-gradient(0.25turn, #3f87a6, #ebf8e1, #f69d3c)' })
+    expect(stringToBackground('https://upload.wikimedia.org/wikipedia/commons/c/ca/1x1.png')).toEqual({ backgroundImage: 'url("https://upload.wikimedia.org/wikipedia/commons/c/ca/1x1.png")' })
+    expect(stringToBackground('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+ip1sAAAAASUVORK5CYII=')).toEqual({ backgroundImage: 'url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+ip1sAAAAASUVORK5CYII=")' })
+  })
+})

--- a/packages/website/src/utils/css.ts
+++ b/packages/website/src/utils/css.ts
@@ -1,0 +1,20 @@
+export const getRGBColor = (hex: string): string => {
+  let color = hex.replace(/#/g, '')
+
+  var r = parseInt(color.substring(0, 2), 16)
+  var g = parseInt(color.substring(2, 4), 16)
+  var b = parseInt(color.substring(4, 6), 16)
+
+  return `${r}, ${g}, ${b}`
+}
+
+export const stringToBackground = (string: string): React.CSSProperties => {
+  type CSSPropertyKeys = keyof React.CSSProperties
+  const hasImageUrl = string.startsWith('http') || string.startsWith('data:image')
+  const key: CSSPropertyKeys = string.toLowerCase().includes('gradient') || hasImageUrl ? 'backgroundImage' : 'backgroundColor'
+  const value = hasImageUrl ? `url("${string}")` : string
+
+  return {
+    [key]: value
+  }
+}


### PR DESCRIPTION
Swatches can now manage image urls and base64 encoded images.

Here below an example:
```diff
{
    "productCode": "BEACHAIR",
    "variantCode": "BEACHAIRFFFFFF",
    "sku": "BEACHAIRFFFFFF000000XXXX",
    "slug": "/white-bean-chair-with-black-logo/BEACHAIRFFFFFF000000XXXX",
    "name": {
      "en": "White Bean Chair with Black Logo",
      "it": "White Bean Chair with Black Logo"
    },
    "description": {
      "en": "Bean bags are the ultimate interior design item to have, and this one's as good as they come! Comfy, sturdy, with a big all-over printed logo.",
      "it": "Bean bags are the ultimate interior design item to have, and this one's as good as they come! Comfy, sturdy, with a big all-over printed logo."
    },
    "images": [
      "https://res.cloudinary.com/commercelayer/image/upload/f_auto,b_white/demo-store/skus/BEACHAIRFFFFFF000000XXXX_FLAT.png",
      "https://res.cloudinary.com/commercelayer/image/upload/f_auto,b_white/demo-store/skus/BEACHAIRFFFFFF000000XXXX_FLAT.png"
    ],
-   "color": "#FFFFFF"
+   "color": "https://upload.wikimedia.org/wikipedia/commons/2/25/Color_icon_orange.png"
  }
```

<img width="125" alt="Screenshot 2022-12-14 alle 17 04 58" src="https://user-images.githubusercontent.com/1681269/207646531-6b5e3587-6f52-4274-a0f1-f95f4e83d151.png">
