### PR TITLE
Update cart link counter when updating the cart on the actual cart page

### DIFF
--- a/packages/website/src/components/Auth.tsx
+++ b/packages/website/src/components/Auth.tsx
@@ -101,7 +101,17 @@ export const Auth: React.FC<Props> = ({ children, locale }) => {
   }, [market, router.asPath, clientId, endpoint])
 
   if (!auth || !endpoint) {
-    return <>{children}</>
+    return (
+      <>
+        <CommerceLayer accessToken='' endpoint=''>
+          <OrderContainer>
+            <LineItemsContainer>
+              {children}
+            </LineItemsContainer>
+          </OrderContainer>
+        </CommerceLayer>
+      </>
+    )
   }
 
   const { hostname } = new URL(endpoint)
@@ -120,7 +130,7 @@ export const Auth: React.FC<Props> = ({ children, locale }) => {
             cart_url
           }}>
             <LineItemsContainer>
-              <>{children}</>
+              {children}
             </LineItemsContainer>
           </OrderContainer>
         </OrderStorage>

--- a/packages/website/src/pages/[locale]/cart/index.page.tsx
+++ b/packages/website/src/pages/[locale]/cart/index.page.tsx
@@ -14,9 +14,11 @@ import type { GetStaticPaths, GetStaticProps } from 'next'
 import { useI18n } from 'next-localization'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
+import { useOrderContainer } from '@commercelayer/react-components/hooks/useOrderContainer'
 
 const CartPage: React.FC<HeaderProps> = ({ navigation }) => {
   const [cartUrl, setCartUrl] = useState<string | null>(null)
+  const { reloadOrder } = useOrderContainer()
 
   const i18n = useI18n()
   const auth = useAuthContext()
@@ -51,6 +53,14 @@ const CartPage: React.FC<HeaderProps> = ({ navigation }) => {
       {
         cartUrl && (
           <IframeResizer
+            checkOrigin={false}
+            onMessage={
+              (event) => {
+                if (event.message.type === 'update') {
+                  reloadOrder()
+                }
+              }
+            }
             style={{ width: '1px', minWidth: '100%' }}
             src={cartUrl} />
         )


### PR DESCRIPTION
The cart link counter is now working properly when the user updates the cart line-items from the actual cart page.

<img src="https://user-images.githubusercontent.com/1681269/207707964-15291526-c938-4fa9-a73a-26ab9e49c3c6.gif" width="600" />
