### PR TITLE
Search page fetches products on the client side rather than at build time

### DIFF
--- a/packages/website/src/components/Search.tsx
+++ b/packages/website/src/components/Search.tsx
@@ -17,7 +17,9 @@ export const Search: React.FC<Props> = ({ className }) => {
   )
 
   useEffect(function manageOnRouterChange() {
-    if (typeof router.query.q !== 'string') {
+    if (typeof router.query.q === 'string') {
+      setValue(router.query.q)
+    } else {
       setValue('')
     }
   }, [router])

--- a/packages/website/src/pages/[locale]/search/SearchPageComponent.tsx
+++ b/packages/website/src/pages/[locale]/search/SearchPageComponent.tsx
@@ -5,13 +5,19 @@ import { ProductCard } from '#components/ProductCard'
 import { Props as SubNavigationProps, SubNavigation } from '#components/SubNavigation'
 import { Title } from '#components/Title'
 import { CatalogProvider, useCatalogContext } from '#contexts/CatalogContext'
-import type { LocalizedProductWithVariant } from '#utils/products'
+import { useSettingsContext } from '#contexts/SettingsContext'
+import { getCatalog } from '#data/models/catalog'
+import { getRawDataProducts } from '#data/products'
+import { flattenReferencesFromCatalog } from '#utils/catalog'
+import { getProductWithVariants, LocalizedProductWithVariant } from '#utils/products'
 import type { NextPage } from 'next'
 import { useI18n } from 'next-localization'
 import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
 
 export type Props = HeaderProps & Partial<SubNavigationProps> & {
   products: LocalizedProductWithVariant[]
+  searching?: boolean
 }
 
 const ProductList: React.FC<{ hasSidebar: boolean }> = ({ hasSidebar }) => {
@@ -45,8 +51,30 @@ const Header: React.FC<Partial<SubNavigationProps>> = ({ subNavigation }) => {
   )
 }
 
-export const SearchPageComponent: NextPage<Props> = ({ navigation, products, subNavigation }) => {
+export const SearchPageComponent: NextPage<Props> = ({ navigation, subNavigation, searching = false, ...props }) => {
   const isSubNavigationVisible = subNavigation !== undefined && !!subNavigation.path.find(c => c.children?.length && c.children.length >= 1)
+
+  const { locale } = useSettingsContext()
+  const [products, setProducts] = useState(props.products)
+
+  useEffect(() => {
+    if (searching === false) {
+      setProducts(props.products)
+    }
+  }, [props.products])
+
+  useEffect(() => {
+    (async () => {
+      if (searching === true && locale !== undefined) {
+        const catalog = await getCatalog(locale)
+        const references = flattenReferencesFromCatalog(catalog)
+
+        const rawDataProducts = await getRawDataProducts()
+        const products = references.map(ref => getProductWithVariants(ref, locale.code, rawDataProducts))
+        setProducts(products)
+      }
+    })()
+  }, [searching, locale?.code])
 
   return (
     <Page

--- a/packages/website/src/pages/[locale]/search/index.dataFetching.tsx
+++ b/packages/website/src/pages/[locale]/search/index.dataFetching.tsx
@@ -1,11 +1,9 @@
 import { serverSideSettings } from '#contexts/SettingsContext'
 import { getCatalog } from '#data/models/catalog'
-import { getRawDataProducts } from '#data/products'
 import { getLocale } from '#i18n/locale'
 import { serverSideTranslations } from '#i18n/serverSideTranslations'
 import { withLocalePaths } from '#i18n/withLocalePaths'
-import { flattenReferencesFromCatalog, getRootNavigationLinks } from '#utils/catalog'
-import { getProductWithVariants } from '#utils/products'
+import { getRootNavigationLinks } from '#utils/catalog'
 import type { GetServerSideProps, GetStaticPaths, GetStaticProps } from 'next'
 import type { Props } from './SearchPageComponent'
 
@@ -25,15 +23,11 @@ export const getStaticProps: GetStaticProps<Props, Query> = async ({ params }) =
   const locale = await getLocale(localeCode)
   const catalog = await getCatalog(locale)
 
-  const references = flattenReferencesFromCatalog(catalog)
-
-  const rawDataProducts = await getRawDataProducts()
-  const products = references.map(ref => getProductWithVariants(ref, locale.code, rawDataProducts))
-
   return {
     props: {
       navigation: getRootNavigationLinks(catalog),
-      products,
+      products: [],
+      searching: true,
       ...(await serverSideSettings(localeCode)),
       ...(await serverSideTranslations(localeCode))
     }


### PR DESCRIPTION
### What does this PR do?

Since `/search` page is excluded from being indexed, the page does not need to be statically generated with all the products. Moving this on the client side will make the build a bit faster and the page size smaller.