### PR TITLE
Countries and languages

### DIFF
--- a/packages/types/src/json/countries.ts
+++ b/packages/types/src/json/countries.ts
@@ -36,12 +36,15 @@ type RawDataCountrySchema = z.ZodObject<{
   catalog: z.ZodString
 
   /**
-   * Default language
+   * Supported language codes
    * 
-   * This attribute is used on the country selector page to define a default language when you select a country.
-   * @example "en"
+   * List of supported language codes for the specific country. A countries can support more than one language.
+   * 
+   * First language code in the list will be used as default language.
+   * The default language is used on the country selector page when you select a country.
+   * @example ["it", "en"]
    */
-  default_language: z.ZodString
+  languages: z.ZodArray<z.ZodString>
 
   /**
    * Region
@@ -57,7 +60,7 @@ const rawDataCountry_schema: RawDataCountrySchema = z.object({
   code: z.string(),
   market: z.number().optional(),
   catalog: z.string(),
-  default_language: z.string(),
+  languages: z.string().array().min(1),
   region: z.string()
 })
 

--- a/packages/website/data/json/countries.json
+++ b/packages/website/data/json/countries.json
@@ -4,7 +4,7 @@
     "code": "US",
     "market": 11279,
     "catalog": "AMER",
-    "default_language": "en",
+    "languages": ["en"],
     "region": "Americas"
   },
   {
@@ -12,7 +12,7 @@
     "code": "AT",
     "market": 11278,
     "catalog": "EMEA",
-    "default_language": "en",
+    "languages": ["en"],
     "region": "Europe"
   },
   {
@@ -20,7 +20,7 @@
     "code": "AU",
     "market": 11279,
     "catalog": "AMER",
-    "default_language": "en",
+    "languages": ["en"],
     "region": "Oceania"
   },
   {
@@ -28,7 +28,7 @@
     "code": "BE",
     "market": 11278,
     "catalog": "EMEA",
-    "default_language": "en",
+    "languages": ["en"],
     "region": "Europe"
   },
   {
@@ -36,7 +36,7 @@
     "code": "BO",
     "market": 11279,
     "catalog": "AMER",
-    "default_language": "en",
+    "languages": ["en"],
     "region": "Americas"
   },
   {
@@ -44,7 +44,7 @@
     "code": "BR",
     "market": 11279,
     "catalog": "AMER",
-    "default_language": "en",
+    "languages": ["en"],
     "region": "Americas"
   },
   {
@@ -52,7 +52,7 @@
     "code": "CA",
     "market": 11279,
     "catalog": "AMER",
-    "default_language": "en",
+    "languages": ["en"],
     "region": "Americas"
   },
   {
@@ -60,7 +60,7 @@
     "code": "CL",
     "market": 11279,
     "catalog": "AMER",
-    "default_language": "en",
+    "languages": ["en"],
     "region": "Americas"
   },
   {
@@ -68,7 +68,7 @@
     "code": "CN",
     "market": 11279,
     "catalog": "APAC",
-    "default_language": "en",
+    "languages": ["en"],
     "region": "Asia"
   },
   {
@@ -76,7 +76,7 @@
     "code": "DK",
     "market": 11278,
     "catalog": "EMEA",
-    "default_language": "en",
+    "languages": ["en"],
     "region": "Europe"
   },
   {
@@ -84,7 +84,7 @@
     "code": "FI",
     "market": 11278,
     "catalog": "EMEA",
-    "default_language": "en",
+    "languages": ["en"],
     "region": "Europe"
   },
   {
@@ -92,7 +92,7 @@
     "code": "FR",
     "market": 11278,
     "catalog": "EMEA",
-    "default_language": "en",
+    "languages": ["en"],
     "region": "Europe"
   },
   {
@@ -100,7 +100,7 @@
     "code": "DE",
     "market": 11278,
     "catalog": "EMEA",
-    "default_language": "en",
+    "languages": ["en"],
     "region": "Europe"
   },
   {
@@ -108,7 +108,7 @@
     "code": "HK",
     "market": 11279,
     "catalog": "APAC",
-    "default_language": "en",
+    "languages": ["en"],
     "region": "Asia"
   },
   {
@@ -116,7 +116,7 @@
     "code": "IN",
     "market": 11279,
     "catalog": "APAC",
-    "default_language": "en",
+    "languages": ["en"],
     "region": "Asia"
   },  
   {
@@ -124,7 +124,7 @@
     "code": "ID",
     "market": 11279,
     "catalog": "APAC",
-    "default_language": "en",
+    "languages": ["en"],
     "region": "Asia"
   },
   {
@@ -132,7 +132,7 @@
     "code": "IE",
     "market": 11278,
     "catalog": "EMEA",
-    "default_language": "en",
+    "languages": ["en"],
     "region": "Europe"
   },
   {
@@ -140,7 +140,7 @@
     "code": "IS",
     "market": 11278,
     "catalog": "EMEA",
-    "default_language": "en",
+    "languages": ["en"],
     "region": "Europe"
   },
   {
@@ -148,7 +148,7 @@
     "code": "IT",
     "market": 11278,
     "catalog": "EMEA",
-    "default_language": "it",
+    "languages": ["it", "en"],
     "region": "Europe"
   },
   {
@@ -156,7 +156,7 @@
     "code": "JP",
     "market": 11279,
     "catalog": "APAC",
-    "default_language": "en",
+    "languages": ["en"],
     "region": "Asia"
   },
   {
@@ -164,7 +164,7 @@
     "code": "KR",
     "market": 11279,
     "catalog": "APAC",
-    "default_language": "en",
+    "languages": ["en"],
     "region": "Asia"
   },
   {
@@ -172,7 +172,7 @@
     "code": "MX",
     "market": 11279,
     "catalog": "AMER",
-    "default_language": "en",
+    "languages": ["en"],
     "region": "Americas"
   },
   {
@@ -180,7 +180,7 @@
     "code": "NL",
     "market": 11278,
     "catalog": "EMEA",
-    "default_language": "en",
+    "languages": ["en"],
     "region": "Europe"
   },
   {
@@ -188,7 +188,7 @@
     "code": "NG",
     "market": 11279,
     "catalog": "EMEA",
-    "default_language": "en",
+    "languages": ["en"],
     "region": "Africa"
   },
   {
@@ -196,7 +196,7 @@
     "code": "NO",
     "market": 11278,
     "catalog": "EMEA",
-    "default_language": "en",
+    "languages": ["en"],
     "region": "Europe"
   },
   {
@@ -204,7 +204,7 @@
     "code": "PL",
     "market": 11278,
     "catalog": "EMEA",
-    "default_language": "en",
+    "languages": ["en"],
     "region": "Europe"
   },
   {
@@ -212,7 +212,7 @@
     "code": "PT",
     "market": 11278,
     "catalog": "EMEA",
-    "default_language": "en",
+    "languages": ["en"],
     "region": "Europe"
   },
   {
@@ -220,7 +220,7 @@
     "code": "RU",
     "market": 11279,
     "catalog": "APAC",
-    "default_language": "en",
+    "languages": ["en"],
     "region": "Asia"
   },
   {
@@ -228,7 +228,7 @@
     "code": "SA",
     "market": 11279,
     "catalog": "APAC",
-    "default_language": "en",
+    "languages": ["en"],
     "region": "Asia"
   },
   {
@@ -236,7 +236,7 @@
     "code": "SG",
     "market": 11279,
     "catalog": "APAC",
-    "default_language": "en",
+    "languages": ["en"],
     "region": "Asia"
   },
   {
@@ -244,7 +244,7 @@
     "code": "ZA",
     "market": 11279,
     "catalog": "EMEA",
-    "default_language": "en",
+    "languages": ["en"],
     "region": "Africa"
   },
   {
@@ -252,7 +252,7 @@
     "code": "ES",
     "market": 11278,
     "catalog": "EMEA",
-    "default_language": "it",
+    "languages": ["it"],
     "region": "Europe"
   },
   {
@@ -260,7 +260,7 @@
     "code": "SE",
     "market": 11278,
     "catalog": "EMEA",
-    "default_language": "en",
+    "languages": ["en"],
     "region": "Europe"
   },
   {
@@ -268,7 +268,7 @@
     "code": "CH",
     "market": 11278,
     "catalog": "EMEA",
-    "default_language": "en",
+    "languages": ["en"],
     "region": "Europe"
   },
   {
@@ -276,7 +276,7 @@
     "code": "TR",
     "market": 11278,
     "catalog": "EMEA",
-    "default_language": "en",
+    "languages": ["en"],
     "region": "Europe"
   },
   {
@@ -284,7 +284,7 @@
     "code": "GB",
     "market": 11280,
     "catalog": "EMEA",
-    "default_language": "en",
+    "languages": ["en"],
     "region": "Europe"
   }
 ]

--- a/packages/website/jest.helpers.tsx
+++ b/packages/website/jest.helpers.tsx
@@ -70,7 +70,7 @@ export const createLocale = (): ShoppableLocale => {
       catalog: 'AMER',
       code: 'US',
       name: 'United States',
-      default_language: 'en',
+      languages: ['en'],
       market: 123456789,
       region: 'Americas'
     },

--- a/packages/website/src/components/CountrySelector.module.scss
+++ b/packages/website/src/components/CountrySelector.module.scss
@@ -9,7 +9,7 @@ $noAccordionBreakpoint: theme('screens.md');
 }
 
 .countriesContainer {
-  @apply container mx-auto px-6;
+  @apply container mx-auto px-6 flex-grow;
 
   @media (min-width: $noAccordionBreakpoint) {
     @apply bg-no-repeat bg-center max-w-screen-2xl bg-contain px-24 pt-24;

--- a/packages/website/src/components/CountrySelector.tsx
+++ b/packages/website/src/components/CountrySelector.tsx
@@ -55,7 +55,7 @@ export const CountrySelector: React.FC<Props> = ({ languages, countries }) => {
 
       {
         internationalLanguage && (
-          <div className='bg-gray-50 border-t border-gray-200 mt-12 pt-6 pb-6 flex flex-grow'>
+          <div className='bg-gray-50 border-t border-gray-200 mt-12 pt-6 pb-6 flex'>
             <div className='container mx-auto px-6'>
               {i18n.t('general.countrySelector.otherCountries')}
               <Link locale={internationalLanguage.code} className='font-semibold block'>

--- a/packages/website/src/components/CountrySelector.tsx
+++ b/packages/website/src/components/CountrySelector.tsx
@@ -40,7 +40,7 @@ export const CountrySelector: React.FC<Props> = ({ languages, countries }) => {
                 <div>
                   {
                     countries.map(country => {
-                      const locale = makeLocaleCode(country.default_language, country.code)
+                      const locale = makeLocaleCode(country.languages[0], country.code)
                       return (
                         <Link key={locale} locale={locale} className={styles.countryLink}>{country.name}</Link>
                       )

--- a/packages/website/src/components/Footer.tsx
+++ b/packages/website/src/components/Footer.tsx
@@ -4,6 +4,7 @@ import { useSettingsContext } from '#contexts/SettingsContext'
 import { getRawDataLanguages } from '#data/languages'
 import { Link } from '#i18n/Link'
 import { changeLanguage, parseLocaleCode } from '#utils/locale'
+import { isNotNullish } from '#utils/utility-types'
 import type { RawDataLanguage } from '@commercelayer/demo-store-types'
 import { useI18n } from 'next-localization'
 import { useRouter } from 'next/router'
@@ -24,7 +25,17 @@ export const Footer: React.FC = () => {
       const rawDataLanguages = await getRawDataLanguages()
 
       if (isMounted) {
-        setLanguages(rawDataLanguages)
+        if (settings.locale?.isShoppable) {
+          setLanguages(
+            settings.locale.country.languages.flatMap(cl => {
+              return rawDataLanguages
+                .filter(lang => lang.code === cl)
+                .filter(isNotNullish)
+            })
+          )
+        } else {
+          setLanguages(rawDataLanguages)
+        }
       }
     })()
 

--- a/packages/website/src/i18n/locale.test.ts
+++ b/packages/website/src/i18n/locale.test.ts
@@ -2,11 +2,20 @@ import type { ShoppableCountry } from '#utils/countries'
 import type { RawDataLanguage } from '@commercelayer/demo-store-types'
 import { getLocale, Locale } from './locale'
 
+const unitedStates: ShoppableCountry = { code: 'US', languages: ['en', 'it'], market: 11279, name: 'United States', region: 'Americas', catalog: 'AMER' }
+const italian: RawDataLanguage = { code: 'it', name: 'Italiano', catalog: 'AMER' }
+const english: RawDataLanguage = { code: 'en', name: 'English', catalog: 'AMER' }
+
+jest.mock('#data/countries', () => ({
+  getRawDataCountries: () => ([unitedStates])
+}))
+
+jest.mock('#data/languages', () => ({
+  getRawDataLanguages: () => ([italian, english])
+}))
+
 describe('getLocale', () => {
   it('should be able to return a Locale given a localeCode', async () => {
-    const unitedStates: ShoppableCountry = { code: 'US', default_language: 'en', market: 11279, name: 'United States', region: 'Americas', catalog: 'AMER' }
-    const italian: RawDataLanguage = { code: 'it', name: 'Italiano', catalog: 'AMER' }
-
     const locale = await getLocale('it-US')
 
     expect(locale).toStrictEqual<Locale>({

--- a/packages/website/src/i18n/withLocalePaths.test.ts
+++ b/packages/website/src/i18n/withLocalePaths.test.ts
@@ -4,8 +4,23 @@ import type { GetStaticPathsResult } from 'next'
 import { getLocales, NonShoppableLocale, ShoppableLocale } from './locale'
 import { withLocalePaths } from './withLocalePaths'
 
-const unitedStates: ShoppableCountry = { code: 'US', default_language: 'en', market: 1234, name: 'United States', region: 'Americas', catalog: 'AMER' }
-const italy: ShoppableCountry = { code: 'IT', default_language: 'it', market: 9876, name: 'Italy', region: 'Europe', catalog: 'EMEA' }
+jest.mock('#data/languages', () => ({
+  getRawDataLanguages: () => ([
+    {
+      "name": "English",
+      "code": "en",
+      "catalog": "AMER"
+    },
+    {
+      "name": "Italiano",
+      "code": "it",
+      "catalog": "AMER"
+    }
+  ])
+}))
+
+const unitedStates: ShoppableCountry = { code: 'US', languages: ['en'], market: 1234, name: 'United States', region: 'Americas', catalog: 'AMER' }
+const italy: ShoppableCountry = { code: 'IT', languages: ['it'], market: 9876, name: 'Italy', region: 'Europe', catalog: 'EMEA' }
 const italian: RawDataLanguage = { code: 'it', name: 'Italiano', catalog: 'AMER' }
 const english: RawDataLanguage = { code: 'en', name: 'English', catalog: 'AMER' }
 

--- a/packages/website/src/pages/[locale]/CustomPageComponent.test.tsx
+++ b/packages/website/src/pages/[locale]/CustomPageComponent.test.tsx
@@ -6,6 +6,21 @@ import { createCarouselPageComponent, createCatalog, createRouter, createTaxon, 
 import { I18nProvider } from 'next-localization'
 import { CustomPageComponent } from './CustomPageComponent'
 
+jest.mock('#data/languages', () => ({
+  getRawDataLanguages: () => ([
+    {
+      "name": "English",
+      "code": "en",
+      "catalog": "AMER"
+    },
+    {
+      "name": "Italiano",
+      "code": "it",
+      "catalog": "AMER"
+    }
+  ])
+}))
+
 const useRouter = jest.spyOn(require('next/router'), 'useRouter')
 
 beforeEach(() => {

--- a/packages/website/src/pages/[locale]/product/ProductPageComponent.test.tsx
+++ b/packages/website/src/pages/[locale]/product/ProductPageComponent.test.tsx
@@ -7,6 +7,21 @@ import { createCatalog, createRouter, createTaxon, createTaxonomy } from 'jest.h
 import { I18nProvider } from 'next-localization'
 import { ProductPageComponent } from './ProductPageComponent'
 
+jest.mock('#data/languages', () => ({
+  getRawDataLanguages: () => ([
+    {
+      "name": "English",
+      "code": "en",
+      "catalog": "AMER"
+    },
+    {
+      "name": "Italiano",
+      "code": "it",
+      "catalog": "AMER"
+    }
+  ])
+}))
+
 const useRouter = jest.spyOn(require('next/router'), 'useRouter')
 
 beforeEach(() => {

--- a/packages/website/src/utils/countries.test.ts
+++ b/packages/website/src/utils/countries.test.ts
@@ -2,10 +2,10 @@ import type { RawDataCountry } from '@commercelayer/demo-store-types'
 import { CountriesByRegion, groupByRegion } from './countries'
 
 test('should be able to group locales by their region', () => {
-  const italy: RawDataCountry = { code: 'IT', default_language: 'it', market: 1234, name: 'Italy', region: 'Europe', catalog: 'AMER' }
-  const unitedStates: RawDataCountry = { code: 'US', default_language: 'en', market: 9876, name: 'United States', region: 'Americas', catalog: 'AMER' }
-  const singapore: RawDataCountry = { code: 'SG', default_language: 'en', market: 9876, name: 'Singapore', region: 'Asia', catalog: 'AMER' }
-  const canada: RawDataCountry = { code: 'CA', default_language: 'en', market: 9876, name: 'Canada', region: 'Americas', catalog: 'AMER' }
+  const italy: RawDataCountry = { code: 'IT', languages: ['it'], market: 1234, name: 'Italy', region: 'Europe', catalog: 'AMER' }
+  const unitedStates: RawDataCountry = { code: 'US', languages: ['en'], market: 9876, name: 'United States', region: 'Americas', catalog: 'AMER' }
+  const singapore: RawDataCountry = { code: 'SG', languages: ['en'], market: 9876, name: 'Singapore', region: 'Asia', catalog: 'AMER' }
+  const canada: RawDataCountry = { code: 'CA', languages: ['en'], market: 9876, name: 'Canada', region: 'Americas', catalog: 'AMER' }
 
   const actual = groupByRegion([italy, unitedStates, singapore, canada])
 

--- a/packages/website/src/utils/locale.test.ts
+++ b/packages/website/src/utils/locale.test.ts
@@ -16,15 +16,14 @@ describe('makeLocaleCode', () => {
 
 describe('makeLocales', () => {
   it('should create locales from a list of countries and languages', () => {
-    const unitedStates: ShoppableCountry = { code: 'US', default_language: 'en', market: 10426, name: 'United States', region: 'Americas', catalog: 'AMER' }
-    const italy: ShoppableCountry = { code: 'IT', default_language: 'it', market: 10427, name: 'Italy', region: 'Europe', catalog: 'EMEA' }
+    const unitedStates: ShoppableCountry = { code: 'US', languages: ['en'], market: 10426, name: 'United States', region: 'Americas', catalog: 'AMER' }
+    const italy: ShoppableCountry = { code: 'IT', languages: ['it', 'en'], market: 10427, name: 'Italy', region: 'Europe', catalog: 'EMEA' }
     const italian: RawDataLanguage = { code: 'it', name: 'ITA', catalog: 'AMER' }
     const english: RawDataLanguage = { code: 'en', name: 'ENG', catalog: 'AMER' }
 
     const actual = makeLocales([italian, english], [unitedStates, italy])
 
     const expects: Locale[] = [
-      { code: "it-US", isShoppable: true, country: unitedStates, language: italian },
       { code: "en-US", isShoppable: true, country: unitedStates, language: english },
       { code: "it-IT", isShoppable: true, country: italy, language: italian },
       { code: "en-IT", isShoppable: true, country: italy, language: english },
@@ -100,7 +99,7 @@ describe('changeLanguage', () => {
 
 describe('Locale.isShoppable property', () => {
   it('should be false when country is not defined', () => {
-    const unitedStates: ShoppableCountry = { code: 'US', default_language: 'en', market: 10426, name: 'United States', region: 'Americas', catalog: 'AMER' }
+    const unitedStates: ShoppableCountry = { code: 'US', languages: ['en'], market: 10426, name: 'United States', region: 'Americas', catalog: 'AMER' }
     const english: RawDataLanguage = { code: 'en', name: 'ENG', catalog: 'AMER' }
 
     const actual = makeLocales([english], [unitedStates])
@@ -114,7 +113,7 @@ describe('Locale.isShoppable property', () => {
   })
 
   it('should be false when country doesn\'t have the market property', () => {
-    const unitedStates: NonShoppableCountry = { code: 'US', default_language: 'en', name: 'United States', region: 'Americas', catalog: 'AMER' }
+    const unitedStates: NonShoppableCountry = { code: 'US', languages: ['en'], name: 'United States', region: 'Americas', catalog: 'AMER' }
     const english: RawDataLanguage = { code: 'en', name: 'ENG', catalog: 'AMER' }
 
     const actual = makeLocales([english], [unitedStates])


### PR DESCRIPTION
### What does this PR do?

Until now, locales have been generated by combining all countries with all languages. From now on, countries can specify a list of supported languages.

Below you can find an example of the changes in `countries.json` that you have to make to solve this breaking change:

```diff
...

 {
   "name": "United States",
   "code": "US",
   "market": 11279,
   "catalog": "AMER",
-  "default_language": "en",
+  "languages": ["en"],
   "region": "Americas"
 },
 {
   "name": "Italy",
   "code": "IT",
   "market": 11278,
   "catalog": "EMEA",
-  "default_language": "it",
+  "languages": ["it", "en"],
   "region": "Europe"
 }

...
```