### PR TITLE
Avoid memoization when SSR

### DIFF
--- a/packages/website/data/catalogs.ts
+++ b/packages/website/data/catalogs.ts
@@ -1,7 +1,7 @@
 import { fetchJsonData } from '#utils/data'
+import { memoize } from '#utils/memoize'
 import { makeUnserializable, Unserializable } from '#utils/unserializable'
 import { RawDataCatalog, rawDataCatalogs_schema } from '@commercelayer/demo-store-types'
-import memoize from 'lodash/memoize'
 
 export const getRawDataCatalogs = memoize(
   async function (): Promise<Unserializable<RawDataCatalog[]>> {

--- a/packages/website/data/countries.ts
+++ b/packages/website/data/countries.ts
@@ -1,6 +1,6 @@
 import { fetchJsonData } from '#utils/data'
+import { memoize } from '#utils/memoize'
 import { rawDataCountries_schema, RawDataCountry } from '@commercelayer/demo-store-types'
-import memoize from 'lodash/memoize'
 
 export const getRawDataCountries = memoize(
   async function (): Promise<RawDataCountry[]> {

--- a/packages/website/data/languages.ts
+++ b/packages/website/data/languages.ts
@@ -1,6 +1,6 @@
 import { fetchJsonData } from '#utils/data'
+import { memoize } from '#utils/memoize'
 import { RawDataLanguage, rawDataLanguages_schema } from '@commercelayer/demo-store-types'
-import memoize from 'lodash/memoize'
 
 export const getRawDataLanguages = memoize(
   async function (): Promise<RawDataLanguage[]> {

--- a/packages/website/data/models/catalog.ts
+++ b/packages/website/data/models/catalog.ts
@@ -7,7 +7,7 @@ import { LocalizedProductWithVariant, spreadProductVariants } from '#utils/produ
 import { makeUnserializable, Unserializable } from '#utils/unserializable'
 import { isNotNullish } from '#utils/utility-types'
 import type { RawDataCatalog, RawDataTaxon, RawDataTaxonomy } from '@commercelayer/demo-store-types'
-import memoize from 'lodash/memoize'
+import { memoize } from '#utils/memoize'
 import uniq from 'lodash/uniq'
 
 export type Catalog = Omit<RawDataCatalog, 'taxonomies'> & {

--- a/packages/website/data/organization.ts
+++ b/packages/website/data/organization.ts
@@ -1,6 +1,6 @@
 import { fetchJsonData } from '#utils/data'
+import { memoize } from '#utils/memoize'
 import { RawDataOrganization, rawDataOrganization_schema } from '@commercelayer/demo-store-types'
-import memoize from 'lodash/memoize'
 
 export const getRawDataOrganization = memoize(
   async function(): Promise<RawDataOrganization> {

--- a/packages/website/data/pages.ts
+++ b/packages/website/data/pages.ts
@@ -1,7 +1,7 @@
 import { fetchJsonData } from '#utils/data'
+import { memoize } from '#utils/memoize'
 import { makeUnserializable, Unserializable } from '#utils/unserializable'
 import { RawDataPages, rawDataPages_schema } from '@commercelayer/demo-store-types'
-import memoize from 'lodash/memoize'
 
 export const getRawDataPages = memoize(
   async function (): Promise<Unserializable<RawDataPages>> {

--- a/packages/website/data/products.ts
+++ b/packages/website/data/products.ts
@@ -1,7 +1,7 @@
 import { fetchJsonData } from '#utils/data'
+import { memoize } from '#utils/memoize'
 import { RawDataProduct as BaseRawDataProduct, rawDataProducts_schema } from '@commercelayer/demo-store-types'
 import type { Price } from '@commercelayer/sdk'
-import memoize from 'lodash/memoize'
 
 export const getRawDataProducts = memoize(
   async function(): Promise<RawDataProduct[]> {

--- a/packages/website/data/taxonomies.ts
+++ b/packages/website/data/taxonomies.ts
@@ -1,7 +1,7 @@
 import { fetchJsonData } from '#utils/data'
+import { memoize } from '#utils/memoize'
 import { makeUnserializable, Unserializable } from '#utils/unserializable'
 import { rawDataTaxonomies_schema, RawDataTaxonomy } from '@commercelayer/demo-store-types'
-import memoize from 'lodash/memoize'
 
 export const getRawDataTaxonomies = memoize(
   async function (): Promise<Unserializable<RawDataTaxonomy[]>> {

--- a/packages/website/data/taxons.ts
+++ b/packages/website/data/taxons.ts
@@ -1,7 +1,7 @@
 import { fetchJsonData } from '#utils/data'
+import { memoize } from '#utils/memoize'
 import { makeUnserializable, Unserializable } from '#utils/unserializable'
 import { RawDataTaxon, rawDataTaxons_schema } from '@commercelayer/demo-store-types'
-import memoize from 'lodash/memoize'
 
 export const getRawDataTaxons = memoize(
   async function (): Promise<Unserializable<RawDataTaxon[]>> {

--- a/packages/website/src/contexts/SettingsContext.tsx
+++ b/packages/website/src/contexts/SettingsContext.tsx
@@ -1,7 +1,7 @@
 import { getRawDataOrganization } from '#data/organization'
 import { getLocale, Locale } from '#i18n/locale'
+import { memoize } from '#utils/memoize'
 import type { RawDataOrganization } from '@commercelayer/demo-store-types'
-import memoize from 'lodash/memoize'
 import { createContext, useContext } from 'react'
 
 export type SettingsContext = {

--- a/packages/website/src/i18n/locale.ts
+++ b/packages/website/src/i18n/locale.ts
@@ -2,8 +2,8 @@ import { getRawDataCountries } from '#data/countries'
 import { getRawDataLanguages } from '#data/languages'
 import type { NonShoppableCountry, ShoppableCountry } from '#utils/countries'
 import { makeLocales } from '#utils/locale'
+import { memoize } from '#utils/memoize'
 import type { RawDataLanguage } from '@commercelayer/demo-store-types'
-import memoize from 'lodash/memoize'
 
 type BaseLocale = {
   code: string

--- a/packages/website/src/i18n/serverSideTranslations.ts
+++ b/packages/website/src/i18n/serverSideTranslations.ts
@@ -1,5 +1,5 @@
 import { fetchLocaleData } from '#utils/data'
-import memoize from 'lodash/memoize'
+import { memoize } from '#utils/memoize'
 import lMerge from 'lodash/merge'
 
 export const serverSideTranslations = memoize(

--- a/packages/website/src/utils/memoize.ts
+++ b/packages/website/src/utils/memoize.ts
@@ -1,0 +1,19 @@
+import lodashMemoize from 'lodash/memoize'
+import envs from './envs'
+
+/**
+ * This memoize function will use `lodash.memoize` only when **`process.env.NEXT_PUBLIC_DATA_FETCHING`** is equal to `ssg`.
+ * 
+ * In all other cases (e.g. `NEXT_PUBLIC_DATA_FETCHING === 'ssr'`) this function **will not** create a memoized function.
+ * 
+ * `lodash.memoize` creates a function that memoizes the result of func. If resolver is provided it determines the cache key for
+ * storing the result based on the arguments provided to the memoized function. By default, the first argument
+ * provided to the memoized function is coerced to a string and used as the cache key. The func is invoked with
+ * the this binding of the memoized function.
+ *
+ * @param func The function to have its output memoized.
+ * @param resolver The function to resolve the cache key.
+ * @return Returns the new memoizing function only when **`process.env.NEXT_PUBLIC_DATA_FETCHING`** is equal to `ssg`.
+ */
+export const memoize: <T extends (...args: any) => any>(func: T, resolver?: (...args: Parameters<T>) => any) => T =
+  envs.NEXT_PUBLIC_DATA_FETCHING === 'ssg' ? lodashMemoize : (func) => func

--- a/packages/website/src/utils/pages.ts
+++ b/packages/website/src/utils/pages.ts
@@ -1,8 +1,8 @@
 import { getRawDataPages } from '#data/pages'
 import { getRawDataProducts } from '#data/products'
 import { translateField } from '#utils/locale'
+import { memoize } from '#utils/memoize'
 import type { RawDataCarousel, RawDataGrid, RawDataHero, RawDataMarkdown, RawDataProductGrid } from '@commercelayer/demo-store-types'
-import memoize from 'lodash/memoize'
 import { getProductWithVariants, LocalizedProductWithVariant } from './products'
 
 export type Image = {


### PR DESCRIPTION
Memoization was preventing new JSON data to be fetched. Disable `memoize` when  `NEXT_PUBLIC_DATA_FETCHING` is set to `ssr`.