### PR TITLE
Improve the error message when missing translation

### DIFF
--- a/packages/website/data/models/catalog.ts
+++ b/packages/website/data/models/catalog.ts
@@ -92,8 +92,8 @@ const getTaxon = memoize(
 const resolveTaxon = async (taxon: RawDataTaxon, locale: string, productList: LocalizedProductWithVariant[]): Promise<Taxon> => {
   return {
     id: taxon.id,
-    label: translateField(taxon.label, locale),
-    description: translateField(taxon.description, locale),
+    label: translateField(taxon, 'label', locale),
+    description: translateField(taxon, 'description', locale),
     name: taxon.name,
     slug: taxon.slug,
     taxons: await Promise.all(
@@ -139,7 +139,7 @@ export async function buildProductDataset(catalog: RawDataCatalog, locale: strin
         [taxonomy.facetKey]: uniq([
           // @ts-expect-error
           ...(productDataset[product.sku][taxonomy.facetKey] || []),
-          `${prevTaxons.length > 0 ? prevTaxons.map(t => `${translateField(t.label, locale)} > `).join('') : ''}${translateField(taxon.label, locale)}`
+          `${prevTaxons.length > 0 ? prevTaxons.map(t => `${translateField(t, 'label', locale)} > `).join('') : ''}${translateField(taxon, 'label', locale)}`
         ])
       }
     })

--- a/packages/website/src/utils/locale.test.ts
+++ b/packages/website/src/utils/locale.test.ts
@@ -1,6 +1,6 @@
 import type { Locale } from '#i18n/locale'
 import type { NonShoppableCountry, ShoppableCountry } from '#utils/countries'
-import type { RawDataLanguage } from '@commercelayer/demo-store-types'
+import type { LocalizedField, RawDataLanguage } from '@commercelayer/demo-store-types'
 import { changeLanguage, makeLocaleCode, makeLocales, parseLocaleCode, translateField } from './locale'
 
 
@@ -51,37 +51,66 @@ describe('parseLocale', () => {
 
 describe('translateField', () => {
   it('should returns the localized field by provided locale (language)', () => {
-    const value = translateField({
-      en: 'English title',
-      it: 'Titolo italiano',
-      'en-US': 'American title'
-    }, 'en')
+    const item: { text: string; localizedField: LocalizedField<string> } = {
+      text: 'string',
+      localizedField: {
+        en: 'English title',
+        it: 'Titolo italiano',
+        'en-US': 'American title'
+      }
+    }
+
+    const value = translateField(item, 'localizedField', 'en')
     expect(value).toStrictEqual('English title')
   })
 
   it('should returns the localized field by provided locale (language + country)', () => {
-    const value = translateField({
-      en: 'English title',
-      it: 'Titolo italiano',
-      'en-US': 'American title'
-    }, 'en-US')
+    const item: { text: string; localizedField: LocalizedField<string> } = {
+      text: 'string',
+      localizedField: {
+        en: 'English title',
+        it: 'Titolo italiano',
+        'en-US': 'American title'
+      }
+    }
+
+    const value = translateField(item, 'localizedField', 'en-US')
     expect(value).toStrictEqual('American title')
   })
 
   it('should fallback to language when provided language-COUNTRY is not found', () => {
-    const value = translateField({
-      en: 'English title',
-      it: 'Titolo italiano',
-      'en-US': 'American title'
-    }, 'it-CN')
+    const item: { text: string; localizedField: LocalizedField<string> } = {
+      text: 'string',
+      localizedField: {
+        en: 'English title',
+        it: 'Titolo italiano',
+        'en-US': 'American title'
+      }
+    }
+
+    const value = translateField(item, 'localizedField', 'it-CN')
     expect(value).toStrictEqual('Titolo italiano')
   })
 
   it('should throw an error when locale and language are not found and also default locale is not available', () => {
-    expect(() => translateField({
-      it: 'Titolo italiano',
-      'en-US': 'American title'
-    }, 'fr-CN')).toThrowError(`Missing translation for locale 'fr-CN' : {"it":"Titolo italiano","en-US":"American title"}`)
+    const item: { text: string; localizedField: LocalizedField<string> } = {
+      text: 'string',
+      localizedField: {
+        it: 'Titolo italiano',
+        'en-US': 'American title'
+      }
+    }
+
+    expect(() => translateField(item, 'localizedField', 'fr-CN')).toThrowError(
+      [
+        `Missing translation for attribute "localizedField".`,
+        `Locale: "fr-CN"`,
+        `Language: "fr"`,
+        `Default: "en"`,
+        '',
+        JSON.stringify(item, undefined, 2)
+      ].join('\n')
+    )
   })
 })
 

--- a/packages/website/src/utils/pages.ts
+++ b/packages/website/src/utils/pages.ts
@@ -140,8 +140,8 @@ export const getPages = memoize(
   async (localeCode: string): Promise<CustomPage[]> => {
     const rawDataPages = await getRawDataPages()
     return await Promise.all(
-      Object.entries(rawDataPages.value).map(async ([slug, page]) => {
-        const localizedPage = translateField(page, localeCode)
+      Object.keys(rawDataPages.value).map(async (slug) => {
+        const localizedPage = translateField(rawDataPages.value, slug, localeCode)
 
         const components = await Promise.all(
           localizedPage.components

--- a/packages/website/src/utils/products.ts
+++ b/packages/website/src/utils/products.ts
@@ -55,12 +55,12 @@ function resolveProductLocale(product: RawDataProduct | LocalizedProduct | Local
   return {
     ...product,
     _locale: locale,
-    name: translateField(product.name, locale),
-    description: translateField(product.description, locale),
+    name: translateField(product, 'name', locale),
+    description: translateField(product, 'description', locale),
     variant,
     details: product.details?.map(detail => ({
-      title: translateField(detail.title, locale),
-      content: translateField(detail.content, locale)
+      title: translateField(detail, 'title', locale),
+      content: translateField(detail, 'content', locale)
     })) || []
   }
 }

--- a/packages/website/src/utils/utility-types.ts
+++ b/packages/website/src/utils/utility-types.ts
@@ -5,3 +5,19 @@
 export function isNotNullish<T>(value: T | null | undefined): value is T {
   return value !== null && value !== undefined
 }
+
+/**
+ * Pick by values
+ * @see https://javascript.plainenglish.io/pick-by-values-in-typescript-a-widely-used-trick-in-many-famous-projects-that-you-should-know-38801eaac1aa
+ * @see https://github.com/piotrwitek/utility-types#pickbyvalueexactt-valuetype
+ */
+export type PickByValueExact<T, ValueType> = Pick<
+  T,
+  {
+    [Key in keyof T]-?: [ValueType] extends [T[Key]]
+    ? [T[Key]] extends [ValueType]
+    ? Key
+    : never
+    : never
+  }[keyof T]
+>


### PR DESCRIPTION
Improve the error message when missing translation.

The message before was:

<img width="796" alt="before" src="https://user-images.githubusercontent.com/1681269/218972440-d01f38d9-fd09-416b-b36c-a3234db36419.png">

After the improvement:

<img width="788" alt="after" src="https://user-images.githubusercontent.com/1681269/218972569-8b24f918-3720-499a-9bcb-6767a389db29.png">
